### PR TITLE
🔧 Update ERNIE-Bot SDK and sample controllers 

### DIFF
--- a/samples/ERNIE-Bot.Sample/Controllers/ApiController.cs
+++ b/samples/ERNIE-Bot.Sample/Controllers/ApiController.cs
@@ -26,7 +26,7 @@ namespace ERNIE_Bot.Sample.Controllers
                 return NoContent();
             }
 
-            var result = await _client.ChatCompletionsAsync(new ChatCompletionsRequest()
+            var result = await _client.ChatAsync(new ChatCompletionsRequest()
             {
                 Messages = new List<Message>
                  {
@@ -36,7 +36,7 @@ namespace ERNIE_Bot.Sample.Controllers
                            Role = MessageRole.User
                       }
                  }
-            });
+            }, ModelEndpoints.ERNIE_Bot);
 
             return Ok(result.Result);
         }
@@ -49,7 +49,7 @@ namespace ERNIE_Bot.Sample.Controllers
                 return NoContent();
             }
 
-            var result = await _client.ChatEBInstantAsync(new ChatCompletionsRequest()
+            var result = await _client.ChatAsync(new ChatCompletionsRequest()
             {
                 Messages = new List<Message>
                  {
@@ -59,7 +59,7 @@ namespace ERNIE_Bot.Sample.Controllers
                            Role = MessageRole.User
                       }
                  }
-            });
+            }, ModelEndpoints.ERNIE_Bot_Turbo);
 
             return Ok(result.Result);
         }
@@ -72,7 +72,7 @@ namespace ERNIE_Bot.Sample.Controllers
                 return NoContent();
             }
 
-            var result = await _client.ChatBLOOMZAsync(new ChatCompletionsRequest()
+            var result = await _client.ChatAsync(new ChatCompletionsRequest()
             {
                 Messages = new List<Message>
                  {
@@ -82,7 +82,7 @@ namespace ERNIE_Bot.Sample.Controllers
                            Role = MessageRole.User
                       }
                  }
-            });
+            }, ModelEndpoints.BLOOMZ_7B);
 
             return Ok(result.Result);
         }
@@ -95,7 +95,7 @@ namespace ERNIE_Bot.Sample.Controllers
                 await Response.CompleteAsync();
             }
 
-            var results = _client.ChatCompletionsStreamAsync(new ChatCompletionsRequest()
+            var results = _client.ChatStreamAsync(new ChatCompletionsRequest()
             {
                 Messages = new List<Message>
                  {
@@ -105,7 +105,7 @@ namespace ERNIE_Bot.Sample.Controllers
                            Role = MessageRole.User
                       }
                  }
-            });
+            }, ModelEndpoints.ERNIE_Bot);
 
             await foreach (var result in results)
             {
@@ -150,10 +150,10 @@ namespace ERNIE_Bot.Sample.Controllers
                 Content = _.Text
             });
 
-            var result = await _client.ChatEBInstantAsync(new ChatCompletionsRequest()
+            var result = await _client.ChatAsync(new ChatCompletionsRequest()
             {
                 Messages = messages.ToList()
-            });
+            }, ModelEndpoints.ERNIE_Bot);
 
             return Ok(result.Result);
         }

--- a/samples/SK-ERNIE-Bot.Sample/Controllers/ApiController.cs
+++ b/samples/SK-ERNIE-Bot.Sample/Controllers/ApiController.cs
@@ -101,7 +101,6 @@ namespace SK_ERNIE_Bot.Sample.Controllers
 
                 {{$input}}
 
-                [ENGLISH]
                 """;
             var func = _kernel.CreateSemanticFunction(prompt);
             var result = await _kernel.RunAsync(input.Text, func);

--- a/samples/SK-ERNIE-Bot.Sample/Program.cs
+++ b/samples/SK-ERNIE-Bot.Sample/Program.cs
@@ -14,8 +14,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddScoped(svc =>
 {
     var kernel = Kernel.Builder
-        .WithERNIEBotTurboChatCompletionService(svc, builder.Configuration, "ernie_bot_turbo", true)
-        .WithERNIEBotChatCompletionService(svc, builder.Configuration, "ernie_bot")
+        .WithERNIEBotChatCompletionService(svc, builder.Configuration, "ernie_bot", ModelEndpoints.ERNIE_Bot)
         .WithERNIEBotEmbeddingGenerationService(svc, builder.Configuration)
         .WithMemoryStorage(new VolatileMemoryStore())
         .Build();

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
 		<PackageProjectUrl>https://github.com/custouch/semantic-kernel-ERNIE-Bot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/custouch/semantic-kernel-ERNIE-Bot</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>0.4.0-preview</Version>
+		<Version>0.5.0-preview</Version>
 		<PackageOutputPath>..\..\nupkgs</PackageOutputPath>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
 		

--- a/src/ERNIE-Bot.SDK/Defaults.cs
+++ b/src/ERNIE-Bot.SDK/Defaults.cs
@@ -8,14 +8,35 @@ namespace ERNIE_Bot.SDK
     {
         public static string AccessTokenEndpoint = "https://aip.baidubce.com/oauth/2.0/token";
 
+        [Obsolete("Use Endpoint() and  ModelEndpoints to get the model endpoint")]
         public static string ERNIEBotEndpoint = "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/completions";
 
+        [Obsolete("Use Endpoint() and  ModelEndpoints to get the model endpoint")]
         public static string ERNIEBotTurboEndpoint = "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/eb-instant";
 
+        [Obsolete("Use Endpoint() and  ModelEndpoints to get the model endpoint")]
         public static string BLOOMZ7BEndpoint = "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/bloomz_7b1";
 
         public static string EmbeddingV1Endpoint = "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/embeddings/embedding-v1";
 
         public static string TokenCacheName = "ERNIE_BOT:AK";
+
+        /// <summary>
+        /// Use ModelEndpoints to get the model name
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        public static string Endpoint(string model) => $"https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/{model}";
+
+    }
+
+    public static class ModelEndpoints
+    {
+        public const string ERNIE_Bot = "completions";
+        public const string ERNIE_Bot_Turbo = "eb-instant";
+        public const string BLOOMZ_7B = "bloomz_7b1";
+        public const string Llama_2_7b_chat = "llama_2_7b";
+        public const string Llama_2_13b_chat = "llama_2_13b";
+        public const string Llama_2_70b_chat = "llama_2_70b";
     }
 }

--- a/src/ERNIE-Bot.SDK/ERNIEBotClient.cs
+++ b/src/ERNIE-Bot.SDK/ERNIEBotClient.cs
@@ -37,9 +37,57 @@ namespace ERNIE_Bot.SDK
         }
 
         /// <summary>
+        ///  API for Chat Completion
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="modelEndpoint"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<ChatResponse> ChatAsync(ChatRequest request, string modelEndpoint, CancellationToken cancellationToken = default)
+        {
+            if (request.Stream.HasValue && request.Stream.Value)
+            {
+                request.Stream = false;
+            }
+
+            OrganizeChatMessages(request.Messages);
+
+            var webRequest = await CreateRequestAsync(HttpMethod.Post, Defaults.Endpoint(modelEndpoint), request);
+
+            var response = await _client.SendAsync(webRequest, cancellationToken);
+
+            return await ParseResponseAsync<ChatResponse>(response);
+        }
+
+        /// <summary>
+        /// Stream API for Chat Completion
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="modelEndpoint"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async IAsyncEnumerable<ChatResponse> ChatStreamAsync(ChatRequest request, string modelEndpoint, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            request.Stream = true;
+
+            OrganizeChatMessages(request.Messages);
+
+            var webRequest = await CreateRequestAsync(HttpMethod.Post, Defaults.Endpoint(modelEndpoint), request, cancellationToken);
+
+            var response = await _client.SendAsync(webRequest, cancellationToken);
+
+            await foreach (var item in ParseResponseStreamAsync(response, cancellationToken))
+            {
+                yield return item;
+            }
+        }
+
+        #region Obsolete 
+        /// <summary>
         /// Api for ERNIE-Bot
         /// </summary>
         /// <returns></returns>
+        [Obsolete("Use ChatAsync and ModelEndpoints.ERNIE_Bot")]
         public async Task<ChatResponse> ChatCompletionsAsync(ChatCompletionsRequest request, CancellationToken cancellationToken = default)
         {
             if (request.Stream.HasValue && request.Stream.Value)
@@ -60,6 +108,7 @@ namespace ERNIE_Bot.SDK
         /// Api for ERNIE-Bot Stream
         /// </summary>
         /// <returns></returns>
+        [Obsolete("Use ChatStreamAsync and ModelEndpoints.ERNIE_Bot")]
         public async IAsyncEnumerable<ChatResponse> ChatCompletionsStreamAsync(ChatCompletionsRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             request.Stream = true;
@@ -76,10 +125,14 @@ namespace ERNIE_Bot.SDK
             }
         }
 
+
+
+
         /// <summary>
         /// Api for ERNIE-Bot-turbo 
         /// </summary>
         /// <returns></returns>
+        [Obsolete("Use ChatAsync and ModelEndpoints.ERNIE_Bot_Turbo")]
         public async Task<ChatResponse> ChatEBInstantAsync(ChatRequest request, CancellationToken cancellationToken = default)
         {
             if (request.Stream.HasValue && request.Stream.Value)
@@ -100,6 +153,7 @@ namespace ERNIE_Bot.SDK
         /// Api for ERNIE-Bot-turbo Stream
         /// </summary>
         /// <returns></returns>
+        [Obsolete("Use ChatStreamAsync and ModelEndpoints.ERNIE_Bot_Turbo")]
         public async IAsyncEnumerable<ChatResponse> ChatEBInstantStreamAsync(ChatRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             request.Stream = true;
@@ -122,6 +176,7 @@ namespace ERNIE_Bot.SDK
         /// <param name="request"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
+        [Obsolete("Use ChatAsync and ModelEndpoints.BLOOMZ")]
         public async Task<ChatResponse> ChatBLOOMZAsync(ChatRequest request, CancellationToken cancellationToken = default)
         {
             if (request.Stream.HasValue && request.Stream.Value)
@@ -142,6 +197,7 @@ namespace ERNIE_Bot.SDK
         /// Api for BLOOMZ-7B Stream
         /// </summary>
         /// <returns></returns>
+        [Obsolete("Use ChatStreamAsync and ModelEndpoints.BLOOMZ")]
         public async IAsyncEnumerable<ChatResponse> ChatBLOOMZStreamAsync(ChatRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             request.Stream = true;
@@ -157,7 +213,7 @@ namespace ERNIE_Bot.SDK
                 yield return item;
             }
         }
-
+        #endregion
 
         /// <summary>
         /// Embedding V1 Api for ERNIE-Bot

--- a/src/ERNIE-Bot.SemanticKernel/ERNIEBotChatCompletion.cs
+++ b/src/ERNIE-Bot.SemanticKernel/ERNIEBotChatCompletion.cs
@@ -12,10 +12,12 @@ using System.Text;
 public class ERNIEBotChatCompletion : IChatCompletion, ITextCompletion
 {
     protected readonly ERNIEBotClient _client;
+    private readonly string _modelEndpoint;
 
-    public ERNIEBotChatCompletion(ERNIEBotClient client)
+    public ERNIEBotChatCompletion(ERNIEBotClient client, string modelEndpoint = ModelEndpoints.ERNIE_Bot)
     {
         this._client = client;
+        this._modelEndpoint = modelEndpoint;
     }
     public ChatHistory CreateNewChat(string? instructions = null)
     {
@@ -73,10 +75,8 @@ public class ERNIEBotChatCompletion : IChatCompletion, ITextCompletion
                                                     cancellationToken
                                                     );
 
-        await foreach (var result in results)
-        {
-            yield return new ERNIEBotChatResult(result);
-        }
+        yield return new ERNIEBotChatResult(results);
+        await Task.CompletedTask;
     }
 
     public async IAsyncEnumerable<ITextStreamingResult> GetStreamingCompletionsAsync(string text, CompleteRequestSettings requestSettings, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -91,10 +91,8 @@ public class ERNIEBotChatCompletion : IChatCompletion, ITextCompletion
                                                      cancellationToken
                                                      );
 
-        await foreach (var result in results)
-        {
-            yield return new ERNIEBotChatResult(result);
-        }
+        yield return new ERNIEBotChatResult(results);
+        await Task.CompletedTask;
     }
 
     private List<Message> StringToMessages(string text)
@@ -129,13 +127,13 @@ public class ERNIEBotChatCompletion : IChatCompletion, ITextCompletion
     {
         try
         {
-            return await _client.ChatCompletionsAsync(new ChatCompletionsRequest()
+            return await _client.ChatAsync(new ChatCompletionsRequest()
             {
                 Messages = messages,
                 Temperature = (float)temperature,
                 TopP = (float)topP,
                 PenaltyScore = (float)presencePenalty,
-            }, cancellationToken);
+            }, _modelEndpoint, cancellationToken);
         }
         catch (ERNIEBotException ex)
         {
@@ -147,13 +145,13 @@ public class ERNIEBotChatCompletion : IChatCompletion, ITextCompletion
     {
         try
         {
-            return _client.ChatCompletionsStreamAsync(new ChatCompletionsRequest()
+            return _client.ChatStreamAsync(new ChatCompletionsRequest()
             {
                 Messages = messages,
                 Temperature = (float)temperature,
                 TopP = (float)topP,
                 PenaltyScore = (float)presencePenalty,
-            }, cancellationToken);
+            }, _modelEndpoint, cancellationToken);
         }
         catch (ERNIEBotException ex)
         {

--- a/src/ERNIE-Bot.SemanticKernel/ERNIEBotKernelBuilderExtensions.cs
+++ b/src/ERNIE-Bot.SemanticKernel/ERNIEBotKernelBuilderExtensions.cs
@@ -13,11 +13,12 @@ namespace Microsoft.SemanticKernel
         public static KernelBuilder WithERNIEBotChatCompletionService(this KernelBuilder builder,
             IServiceProvider service, IConfiguration configuration,
             string? serviceId = null,
+            string modelEndpoint = ModelEndpoints.ERNIE_Bot,
             bool alsoAsTextCompletion = true,
             bool setAsDefault = false)
         {
             var client = CreateERNIEBotClient(service, configuration);
-            var generation = new ERNIEBotChatCompletion(client);
+            var generation = new ERNIEBotChatCompletion(client, modelEndpoint);
             builder.WithAIService<IChatCompletion>(serviceId, generation, setAsDefault);
 
             if (alsoAsTextCompletion)
@@ -31,11 +32,12 @@ namespace Microsoft.SemanticKernel
         public static KernelBuilder WithERNIEBotChatCompletionService(this KernelBuilder builder,
             string clientId, string secret,
             string? serviceId = null,
+            string modelEndpoint = ModelEndpoints.ERNIE_Bot,
             bool alsoAsTextCompletion = true,
             bool setAsDefault = false)
         {
             var client = CreateERNIEBotClient(clientId, secret);
-            var generation = new ERNIEBotChatCompletion(client);
+            var generation = new ERNIEBotChatCompletion(client, modelEndpoint);
             builder.WithAIService<IChatCompletion>(serviceId, generation, setAsDefault);
 
             if (alsoAsTextCompletion)
@@ -46,6 +48,7 @@ namespace Microsoft.SemanticKernel
             return builder;
         }
 
+        [Obsolete("Use WithERNIEBotChatCompletionService instead, and using modelEndpoint = ModelEndpoints.ERNIE_Bot_turbo")]
         public static KernelBuilder WithERNIEBotTurboChatCompletionService(this KernelBuilder builder,
             IServiceProvider service, IConfiguration configuration,
             string? serviceId = null,
@@ -64,6 +67,7 @@ namespace Microsoft.SemanticKernel
             return builder;
         }
 
+        [Obsolete("Use WithERNIEBotChatCompletionService instead, and using modelEndpoint = ModelEndpoints.ERNIE_Bot_turbo")]
         public static KernelBuilder WithERNIEBotTurboChatCompletionService(this KernelBuilder builder,
             string clientId, string secret,
             string? serviceId = null,

--- a/src/ERNIE-Bot.SemanticKernel/ERNIEBotTurboChatCompletion.cs
+++ b/src/ERNIE-Bot.SemanticKernel/ERNIEBotTurboChatCompletion.cs
@@ -2,6 +2,7 @@
 using ERNIE_Bot.SDK.Models;
 using Microsoft.SemanticKernel.AI;
 
+[Obsolete("Please use ERNIEBotChatCompletion instead")]
 public class ERNIEBotTurboChatCompletion : ERNIEBotChatCompletion
 {
     public ERNIEBotTurboChatCompletion(ERNIEBotClient client) : base(client)

--- a/src/ERNIE-Bot.SemanticKernel/readme.md
+++ b/src/ERNIE-Bot.SemanticKernel/readme.md
@@ -18,10 +18,8 @@ dotnet add package ERNIE-Bot.SemanticKernel --prerelease
 builder.Services.AddScoped(svc =>
 {
     var kernel = Kernel.Builder
-        // 使用 ERNIE Bot Turbo
-        .WithERNIEBotTurboChatCompletionService(svc, builder.Configuration, "ernie_bot_turbo", true)
         // 使用 ERNIE Bot
-        .WithERNIEBotChatCompletionService(svc, builder.Configuration, "ernie_bot")
+        .WithERNIEBotChatCompletionService(svc, builder.Configuration, "ernie_bot", ModelEndpoints.ERNIE_Bot)
         // 使用 Embedding
         .WithERNIEBotEmbeddingGenerationService(svc, builder.Configuration)
         .WithMemoryStorage(new VolatileMemoryStore())

--- a/tests/ERNIE-Bot.SDK.Tests/ERNIEBotClientTests.cs
+++ b/tests/ERNIE-Bot.SDK.Tests/ERNIEBotClientTests.cs
@@ -30,7 +30,7 @@ namespace ERNIE_Bot.SDK.Tests
             var fakeTokenStore = new TokenStoreHelper("test_token");
             var client = new ERNIEBotClient("test", "test", httpClient, fakeTokenStore);
 
-            var result = await client.ChatCompletionsAsync(new ChatCompletionsRequest()
+            var result = await client.ChatAsync(new ChatCompletionsRequest()
             {
                 Messages =
                 {
@@ -40,7 +40,7 @@ namespace ERNIE_Bot.SDK.Tests
                          Content = "Hello?"
                     }
                 }
-            });
+            }, ModelEndpoints.ERNIE_Bot);
 
             Assert.NotEmpty(result.Result);
         }
@@ -52,7 +52,7 @@ namespace ERNIE_Bot.SDK.Tests
             var fakeTokenStore = new TokenStoreHelper("test_token");
             var client = new ERNIEBotClient("test", "test", httpClient, fakeTokenStore);
 
-            var results = client.ChatCompletionsStreamAsync(new ChatCompletionsRequest()
+            var results = client.ChatStreamAsync(new ChatCompletionsRequest()
             {
                 Messages =
                 {
@@ -62,7 +62,7 @@ namespace ERNIE_Bot.SDK.Tests
                          Content = "Hello?"
                     }
                 }
-            });
+            }, ModelEndpoints.ERNIE_Bot);
 
             await foreach (var result in results)
             {
@@ -77,7 +77,7 @@ namespace ERNIE_Bot.SDK.Tests
             var fakeTokenStore = new TokenStoreHelper("test_token");
             var client = new ERNIEBotClient("test", "test", httpClient, fakeTokenStore);
 
-            var result = await client.ChatEBInstantAsync(new ChatRequest()
+            var result = await client.ChatAsync(new ChatRequest()
             {
                 Messages =
                 {
@@ -87,7 +87,7 @@ namespace ERNIE_Bot.SDK.Tests
                          Content = "Hello?"
                     }
                 }
-            });
+            }, ModelEndpoints.ERNIE_Bot_Turbo);
 
             Assert.NotEmpty(result.Result);
         }
@@ -99,7 +99,7 @@ namespace ERNIE_Bot.SDK.Tests
             var fakeTokenStore = new TokenStoreHelper("test_token");
             var client = new ERNIEBotClient("test", "test", httpClient, fakeTokenStore);
 
-            var results = client.ChatEBInstantStreamAsync(new ChatRequest()
+            var results = client.ChatStreamAsync(new ChatRequest()
             {
                 Messages =
                 {
@@ -109,7 +109,7 @@ namespace ERNIE_Bot.SDK.Tests
                          Content = "Hello?"
                     }
                 }
-            });
+            }, ModelEndpoints.ERNIE_Bot_Turbo);
 
             await foreach (var result in results)
             {


### PR DESCRIPTION
- Add Llama-2 model endpoints
- Renamed method `ChatCompletionsAsync` to `ChatAsync` in ApiController.cs
- Updated the model endpoint in Program.cs
- Added a new method `ChatAsync` in ERNIEBotClient.cs
- Added a new method `ChatStreamAsync` in ERNIEBotClient.cs
- Updated the model endpoints in Defaults.cs

These changes improve the functionality and maintainability of the ERNIE-Bot SDK and sample controllers.