### PR TITLE
🔀 Update ERNIEBotChatCompletion message handling

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,24 +8,24 @@
 		<LangVersion>12</LangVersion>
 		<Authors>Custouch</Authors>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		
+
 		<PackageProjectUrl>https://github.com/custouch/semantic-kernel-ERNIE-Bot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/custouch/semantic-kernel-ERNIE-Bot</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>0.13.0</Version>
+		<Version>0.13.1</Version>
 		<PackageOutputPath>..\..\nupkgs</PackageOutputPath>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
 		<NoWarn>SKEXP0001;SKEXP0002;SKEXP0052;SKEXP0003</NoWarn>
-		
+
 	</PropertyGroup>
-	
+
 	<ItemGroup>
 		<None Include="..\..\LICENSE">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<None Include="readme.md">
 			<Pack>True</Pack>
@@ -36,5 +36,5 @@
 	<PropertyGroup Condition="$(Configuration) == 'Release'">
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
-	
+
 </Project>

--- a/src/ERNIE-Bot.SemanticKernel/ERNIEBotChatCompletion.cs
+++ b/src/ERNIE-Bot.SemanticKernel/ERNIEBotChatCompletion.cs
@@ -12,11 +12,9 @@ public class ERNIEBotChatCompletion : IChatCompletionService, ITextGenerationSer
 {
     protected readonly ERNIEBotClient _client;
     private readonly ModelEndpoint _modelEndpoint;
-    private readonly Dictionary<string, string> _attributes = new();
+    private readonly Dictionary<string, object?> _attributes = new();
 
-    public IReadOnlyDictionary<string, string> Attributes => this._attributes;
-
-    IReadOnlyDictionary<string, object?> IAIService.Attributes => throw new NotImplementedException();
+    public IReadOnlyDictionary<string, object?> Attributes => this._attributes;
 
     public ERNIEBotChatCompletion(ERNIEBotClient client, ModelEndpoint? modelEndpoint = null)
     {
@@ -116,26 +114,30 @@ public class ERNIEBotChatCompletion : IChatCompletionService, ITextGenerationSer
     }
     private List<Message> StringToMessages(string text)
     {
-        return new List<Message>()
-        {
+        return
+        [
             new Message()
             {
-                 Role = MessageRole.User,
-                 Content = text
+                Role = MessageRole.User,
+                Content = text
             }
-        };
+        ];
     }
 
     private List<Message> ChatHistoryToMessages(ChatHistory chatHistory, out string? system)
     {
+        system = null;
+
+        if (chatHistory.Count == 1)
+        {
+            return StringToMessages(chatHistory.First().Content!);
+        }
+
         if (chatHistory.First().Role == AuthorRole.System)
         {
             system = chatHistory.First().Content;
         }
-        else
-        {
-            system = null;
-        }
+
         return chatHistory
             .Where(_ => _.Role != AuthorRole.System)
             .Select(m => new Message()


### PR DESCRIPTION
- Refactor the `ChatHistoryToMessages` method to handle cases where the `chatHistory` contains only one message.
- Update the return type of the `ChatHistoryToMessages` method to include the `system` parameter.
- Improve code readability and remove unnecessary code.
- 
fixes #86 